### PR TITLE
Fix TypeError in authenticate_with_apikey

### DIFF
--- a/python/WaApi.py
+++ b/python/WaApi.py
@@ -47,7 +47,7 @@ class WaApiClient(object):
         encoded_data = urllib.parse.urlencode(data).encode()
         request = urllib.request.Request(self.auth_endpoint, encoded_data, method="POST")
         request.add_header("ContentType", "application/x-www-form-urlencoded")
-        request.add_header("Authorization", 'Basic ' + base64.standard_b64encode(('APIKEY' + ':' + api_key).encode()))
+        request.add_header("Authorization", 'Basic ' + base64.standard_b64encode(('APIKEY:' + api_key).encode()).decode())
         response = urllib.request.urlopen(request)
         self._token = WaApiClient._parse_response(response)
         self._token.retrieved_at = datetime.datetime.now()


### PR DESCRIPTION
authenticate_with_apikey throws the following traceback

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    api.authenticate_with_apikey("REDACTED")
  File "WaApi.py", line 50, in authenticate_with_apikey
    request.add_header("Authorization", 'Basic ' + base64.standard_b64encode(('APIKEY' + ':' + api_key).encode()))
TypeError: Can't convert 'bytes' object to str implicitly
```

This patch fixes it.