### PR TITLE
Fixed typo in object name in C# example

### DIFF
--- a/C#/SampleConsoleApp/PublicAPI.Samples/ApiV2Sample.cs
+++ b/C#/SampleConsoleApp/PublicAPI.Samples/ApiV2Sample.cs
@@ -248,7 +248,7 @@
                 password, 
                 "auto");
 
-            throw new NonImplementedException("Change clientId and clientSecret to values specific for your authirized application. For details see: https://help.wildapricot.com/display/DOC/Authorizing+external+applications");
+            throw new NotImplementedException("Change clientId and clientSecret to values specific for your authirized application. For details see: https://help.wildapricot.com/display/DOC/Authorizing+external+applications");
             
             var clientId = "MySampleApplication";
             var clientSecret = "open_wa_api_client";


### PR DESCRIPTION
C# example doesn't compile out-of-the-box because of a typo in the object name, so this PR fixes it and the sample builds.