### PR TITLE
Include request for refresh token with APIKEY auth

### DIFF
--- a/python/WaApi.py
+++ b/python/WaApi.py
@@ -42,7 +42,8 @@ class WaApiClient(object):
         scope = "auto" if scope is None else scope
         data = {
             "grant_type": "client_credentials",
-            "scope": scope
+            "scope": scope,
+            "obtain_refresh_token": "true"
         }
         encoded_data = urllib.parse.urlencode(data).encode()
         request = urllib.request.Request(self.auth_endpoint, encoded_data, method="POST")


### PR DESCRIPTION
Include request to generate a refresh token using APIKEY authentication.

Without this, the code is fundamentally broken:  Calls to _refresh_auth_token() will always fail.

Also, this code is fundamentally broken for python3; python2 is officially deprecated.  Oof.